### PR TITLE
#3 出力されるプラグインの相対パスの修正

### DIFF
--- a/src/Sha256Hasher.cpp
+++ b/src/Sha256Hasher.cpp
@@ -51,7 +51,7 @@ Sha256Hasher::~Sha256Hasher()
     }
 }
 
-std::string Sha256Hasher::getFileHash(const char* path)
+std::string Sha256Hasher::getFileHash(const std::filesystem::path& path)
 {
     ifstream fp(path, ios::in | ios::binary);
     if (!fp.good()) {

--- a/src/Sha256Hasher.hpp
+++ b/src/Sha256Hasher.hpp
@@ -2,6 +2,7 @@
 
 #include <Windows.h>
 #include <string>
+#include <filesystem>
 
 class Sha256Hasher
 {
@@ -9,7 +10,7 @@ public:
     Sha256Hasher();
     ~Sha256Hasher();
 
-    std::string getFileHash(const char* path);
+    std::string getFileHash(const std::filesystem::path& path);
 
 private:
     BCRYPT_ALG_HANDLE _hAlg;


### PR DESCRIPTION
issue #3 の対応

今までプラグインの相対パスは以下の様に出力されていた。
```
..\exedit.auf
..\plugins\exedit.auf
```

これを以下の様に出力されるように修正した。
```
exedit.auf
plugins/exedit.auf
```