### PR TITLE
#4 拡張子が.aulのプラグインの情報を出力する機能を追加

### DIFF
--- a/src/AviUtlProfiler.hpp
+++ b/src/AviUtlProfiler.hpp
@@ -75,4 +75,6 @@ private:
     uint32_t ReadUInt32(size_t offset) const {
         return *reinterpret_cast<uint32_t*>(reinterpret_cast<size_t>(hinst_) + offset);
     }
+
+    void WriteOtherPluginsProfile(std::ostream& dest, const PluginsOption& opt);
 };


### PR DESCRIPTION
issue #4 の対応

patch.aul の情報を出力するために、プロセスにロードされているモジュールを調べ、拡張子が.aulのものについて情報を出力するようにした。
区分は「その他のプラグイン」とした。

なお、aulプラグインの本来の機能である言語拡張リソースについては、AviUtl起動時に設定されているプラグインのみしかロードされず、本プラグインで出力される情報にもその1個のみが出力される。
ただし、言語拡張リソース(aul)の情報を出力する需要はかなり少ないと思われるので、一旦このままとする。
