### PR TITLE
:sparkles: feat: 表にexedit.iniの[extension]のバッファ使用率を追加

### DIFF
--- a/src/ExEditProfiler.hpp
+++ b/src/ExEditProfiler.hpp
@@ -34,6 +34,9 @@ public:
     static constexpr size_t kExaExoOffset = 0x135c70;
     static constexpr size_t kExaExoMax = 0x10000;
 
+    static constexpr size_t kExtensionOffset = 0x14cb58;
+    static constexpr size_t kExtensionMax = 0x800;
+
     static constexpr std::string_view kExEditName{ "拡張編集" };
     static constexpr std::string_view kExEdit92{ "拡張編集(exedit) version 0.92 by ＫＥＮくん" };
 
@@ -84,6 +87,10 @@ public:
 
     size_t GetExaExoUsed() const {
         return GetNamesBufferUsed(kExaExoOffset, kExaExoMax);
+    }
+
+    size_t GetExtensionUsed() const {
+        return GetNamesBufferUsed(kExtensionOffset, kExtensionMax);
     }
 
     void WriteProfile(std::ostream& dest, const ScriptsOption& opt);

--- a/src/show_limit.cpp
+++ b/src/show_limit.cpp
@@ -134,10 +134,11 @@ bool CreateFilterWindow(FilterPlugin* fp) {
     SetListItem(5, "図形名", g_exedit_profiler.GetFigureUsed(), ExEditProfiler::kFigureMax);
     SetListItem(6, "トランジション名", g_exedit_profiler.GetTransitionUsed(), ExEditProfiler::kTransitionMax);
     SetListItem(7, "EXA/EXO", g_exedit_profiler.GetExaExoUsed(), ExEditProfiler::kExaExoMax);
-    SetListItem(8, "入力プラグイン", g_aviutl_profiler.GetInputNum(), AviUtlProfiler::kInputCountMax);
-    SetListItem(9, "出力プラグイン", g_aviutl_profiler.GetOutputNum(), AviUtlProfiler::kOutputCountMax);
-    SetListItem(10, "フィルタプラグイン", g_aviutl_profiler.GetFilterNum(), AviUtlProfiler::kFilterCountMax);
-    SetListItem(11, "色変換プラグイン", g_aviutl_profiler.GetColorNum(), AviUtlProfiler::kColorCountMax);
+    SetListItem(8, "exedit extension", g_exedit_profiler.GetExtensionUsed(), ExEditProfiler::kExtensionMax);
+    SetListItem(9, "入力プラグイン", g_aviutl_profiler.GetInputNum(), AviUtlProfiler::kInputCountMax);
+    SetListItem(10, "出力プラグイン", g_aviutl_profiler.GetOutputNum(), AviUtlProfiler::kOutputCountMax);
+    SetListItem(11, "フィルタプラグイン", g_aviutl_profiler.GetFilterNum(), AviUtlProfiler::kFilterCountMax);
+    SetListItem(12, "色変換プラグイン", g_aviutl_profiler.GetColorNum(), AviUtlProfiler::kColorCountMax);
 
     // プラグイングループ
     HWND hwnd = CreateWindowEx(


### PR DESCRIPTION
exedit.ini の [extension] の情報を格納しているバッファ使用率を表に追加。

[nazonoSAUNA](https://github.com/nazonoSAUNA) 氏の情報提供に感謝。