### PR TITLE
Feat/language resource plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(ShowLimit SHARED
     src/ExEditProfiler.cpp
     src/NamesBuffer.hpp
     src/ScriptsOption.hpp
+    src/LanguagePlugin.hpp
 )
 target_include_directories(ShowLimit PRIVATE
     ${AVIUTL_INCLUDE_DIR}

--- a/src/AviUtlProfiler.cpp
+++ b/src/AviUtlProfiler.cpp
@@ -79,11 +79,9 @@ void AviUtlProfiler::WritePluginsProfile(std::ostream& dest, const PluginsOption
     if (opt.enable_count == 0)
         return;
 
-    auto base = reinterpret_cast<size_t>(hinst_);
-
     if (IsSupported()) {
         dest << kBullet1 << "入力プラグイン\n";
-        auto inputs = reinterpret_cast<AviUtl::InputPlugin*>(base + kInputArrayOffset);
+        auto inputs = GetPtr<AviUtl::InputPlugin>(kInputArrayOffset);
         auto input_num = GetInputNum();
         for (size_t i = 0; i < input_num; i++) {
             if (HasFlag(inputs[i].flag, AviUtl::detail::InputPluginFlag::Builtin))
@@ -95,7 +93,7 @@ void AviUtlProfiler::WritePluginsProfile(std::ostream& dest, const PluginsOption
         if (opt.enable_count == 1) dest << "\n";
 
         dest << kBullet1 << "出力プラグイン\n";
-        auto outputs = reinterpret_cast<AviUtl::OutputPlugin*>(base + kOutputArrayOffset);
+        auto outputs = GetPtr<AviUtl::OutputPlugin>(kOutputArrayOffset);
         auto output_num = GetOutputNum();
         for (size_t i = 0; i < output_num; i++) {
             if (HasFlag(outputs[i].flag, AviUtl::detail::OutputPluginFlag::Builtin))
@@ -124,7 +122,7 @@ void AviUtlProfiler::WritePluginsProfile(std::ostream& dest, const PluginsOption
 
     if (IsSupported()) {
         dest << kBullet1 << "色変換プラグイン\n";
-        auto colors = reinterpret_cast<AviUtl::ColorPlugin*>(base + kColorArrayOffset);
+        auto colors = GetPtr<AviUtl::ColorPlugin>(kColorArrayOffset);
         auto color_num = GetColorNum();
         for (size_t i = 0; i < color_num; i++) {
             if (HasFlag(colors[i].flag, AviUtl::detail::ColorPluginFlag::Builtin))

--- a/src/AviUtlProfiler.cpp
+++ b/src/AviUtlProfiler.cpp
@@ -135,6 +135,16 @@ void AviUtlProfiler::WritePluginsProfile(std::ostream& dest, const PluginsOption
         }
         if (opt.enable_count == 1)
             dest << "\n";
+
+        dest << kBullet1 << "言語拡張リソースプラグイン\n";
+        auto langs = GetPtr<LanguagePlugin>(kLanguageArrayOffset);
+        auto lang_num = GetLanguageNum();
+        for (size_t i = 1; i < lang_num; i++) {
+            WritePluginData(dest, hasher, opt, aviutl_dir,
+                langs[i].name, langs[i].information, langs[i].path);
+        }
+        if (opt.enable_count == 1)
+            dest << "\n";
     }
 
     WriteOtherPluginsProfile(dest, opt);
@@ -160,7 +170,7 @@ void AviUtlProfiler::WriteOtherPluginsProfile(std::ostream& dest, const PluginsO
     fs::path aviutl_dir = aviutl_path.parent_path();
     do {
         fs::path plugin_path = me32.szExePath;
-        if (plugin_path.extension() != ".aul") {
+        if (plugin_path.extension() != ".aul" || IsLanguagePlugin(plugin_path.string().c_str())) {
             continue;
         }
 

--- a/src/AviUtlProfiler.hpp
+++ b/src/AviUtlProfiler.hpp
@@ -94,7 +94,7 @@ private:
     }
 
     uint32_t ReadUInt32(size_t offset) const {
-        return *reinterpret_cast<uint32_t*>(reinterpret_cast<size_t>(hinst_) + offset);
+        return *GetPtr<uint32_t>(offset);
     }
 
     bool IsLanguagePlugin(const char* path) const {

--- a/src/LanguagePlugin.hpp
+++ b/src/LanguagePlugin.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+struct LanguagePlugin
+{
+    int32_t sub_language;
+    int32_t language;
+    char name[260];
+    char path[260];
+    char information[260];
+};

--- a/src/show_limit.cpp
+++ b/src/show_limit.cpp
@@ -139,6 +139,7 @@ bool CreateFilterWindow(FilterPlugin* fp) {
     SetListItem(10, "出力プラグイン", g_aviutl_profiler.GetOutputNum(), AviUtlProfiler::kOutputCountMax);
     SetListItem(11, "フィルタプラグイン", g_aviutl_profiler.GetFilterNum(), AviUtlProfiler::kFilterCountMax);
     SetListItem(12, "色変換プラグイン", g_aviutl_profiler.GetColorNum(), AviUtlProfiler::kColorCountMax);
+    SetListItem(13, "言語拡張リソースプラグイン", g_aviutl_profiler.GetLanguageNum(), AviUtlProfiler::kLanguageCountMax);
 
     // プラグイングループ
     HWND hwnd = CreateWindowEx(


### PR DESCRIPTION
#11 の対応。
言語拡張リソースプラグインの情報を表とテキスト出力（クリップボードにコピー、ファイルに保存）に追加しました。
それに伴い、今まではロードしている言語拡張リソースプラグインを「その他のプラグイン」の項目に出力していましたが、ここには出力しないよう修正しました。