### PR TITLE
fix: 組込フィルタプラグインの判定方法の変更

### DIFF
--- a/src/AviUtlProfiler.cpp
+++ b/src/AviUtlProfiler.cpp
@@ -109,7 +109,7 @@ void AviUtlProfiler::WritePluginsProfile(std::ostream& dest, const PluginsOption
     auto filter_num = GetFilterNum();
     for (size_t i = 0; i < filter_num; i++) {
         auto fp = exfunc_->get_filterp(i);
-        if (HasFlag(fp->flag, AviUtl::detail::FilterPluginFlag::Builtin))
+        if (fp->dll_hinst == NULL)
             continue;
 
         char buf[MAX_PATH];


### PR DESCRIPTION
#9 への対応

組込でないフィルタプラグインでも `Builtin` フラグが立っている場合があるということで、組込フィルタを `dll_hinst` が `NULL` かどうかで判定する。
他の入力、出力、色変換プラグインにおいて組込でなくても `Builtin` フラグが立っている場合への対応については、現状その事例を確認していないことから一旦対応を見送った。