### PR TITLE
feat: 表にexfunc->add_menu_itemの使用状況を追加

### DIFF
--- a/src/AviUtlProfiler.hpp
+++ b/src/AviUtlProfiler.hpp
@@ -30,6 +30,9 @@ public:
     static constexpr size_t kLanguageArrayOffset = 0x2d5660;
     static constexpr size_t kLanguageCountMax = 16;
 
+    static constexpr size_t kMenuItemOffset = 0xa8e3c;
+    static constexpr size_t kMenuItemMax = 256;
+
     void Init(AviUtl::FilterPlugin* filter) {
         exfunc_ = filter->exfunc;
         hinst_ = filter->hinst_parent;
@@ -73,6 +76,11 @@ public:
             }
         }
         return kLanguageCountMax;
+    }
+
+    size_t GetMenuItemNum() const {
+        if (!IsSupported()) return 0;
+        return ReadUInt32(kMenuItemOffset);
     }
 
     std::string GetAviUtlPath() const {

--- a/src/show_limit.cpp
+++ b/src/show_limit.cpp
@@ -140,6 +140,7 @@ bool CreateFilterWindow(FilterPlugin* fp) {
     SetListItem(11, "フィルタプラグイン", g_aviutl_profiler.GetFilterNum(), AviUtlProfiler::kFilterCountMax);
     SetListItem(12, "色変換プラグイン", g_aviutl_profiler.GetColorNum(), AviUtlProfiler::kColorCountMax);
     SetListItem(13, "言語拡張リソースプラグイン", g_aviutl_profiler.GetLanguageNum(), AviUtlProfiler::kLanguageCountMax);
+    SetListItem(14, "add_menu_item", g_aviutl_profiler.GetMenuItemNum(), AviUtlProfiler::kMenuItemMax);
 
     // プラグイングループ
     HWND hwnd = CreateWindowEx(


### PR DESCRIPTION
`exfunc->add_menu_item` で追加できるメニュー項目は上限256個で、それを超えて `add_menu_item` してもメニュー項目は追加されずエラー等も表示されない。
この `add_menu_item` の使用状況を表に追加した。

[nazonoSAUNA](https://github.com/nazonoSAUNA) 氏の情報提供に感謝。