### PR TITLE
ビルド関連の設定を更新

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 charset = utf-8
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,4 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
-
-[*.{c,cpp,h,hpp}]
-charset = cp932
+charset = utf-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,1 @@
 * text=auto
-
-*.h text working-tree-encoding=cp932
-*.c text working-tree-encoding=cp932
-*.hpp text working-tree-encoding=cp932
-*.cpp text working-tree-encoding=cp932

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Windows Executable
+name: Build Windows Plugin
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build Windows Executable
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up MSVC
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Configure CMake
+      run: cmake --preset default
+
+    - name: Build
+      run: cmake --build build --preset release
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: aviutl_ShowLimit
+        path: build/Release/ShowLimit.auf

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 [Bb]uild/
-[Vv]endor/
 *.auf
 
 # User-specific files

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 [Bb]uild/
 *.auf
+CMakeUserPresets.json
 
 # User-specific files
 *.rsuser

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/aviutl_exedit_sdk"]
+	path = vendor/aviutl_exedit_sdk
+	url = https://github.com/ePi5131/aviutl_exedit_sdk

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,2 @@
 {
-    "[c]": {
-        "files.encoding": "shiftjis"
-    },
-    "[cpp]": {
-        "files.encoding": "shiftjis"
-    }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "CMake: Build (Debug)",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "${workspaceFolder}/build",
+                "--preset",
+                "debug"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "detail": "デバッグビルド"
+        },
+        {
+            "type": "shell",
+            "label": "CMake: Build (Release)",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "${workspaceFolder}/build",
+                "--preset",
+                "release"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "detail": "リリースビルド"
+        }
+    ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(aviutl_ShowLimit)
-
-set(AVIUTL_INCLUDE_DIR "vendor" CACHE PATH "AviUtl Plugin SDK include dir")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -20,8 +18,11 @@ add_library(ShowLimit SHARED
     src/LanguagePlugin.hpp
 )
 target_include_directories(ShowLimit PRIVATE
-    ${AVIUTL_INCLUDE_DIR}
-    ${AVIUTL_INCLUDE_DIR}/aviutl_exedit_sdk
+    vendor/aviutl_exedit_sdk
 )
 target_link_libraries(ShowLimit comctl32 bcrypt)
+target_compile_options(ShowLimit
+    PRIVATE
+        "$<$<CXX_COMPILER_ID:MSVC>:/source-charset:utf-8>"
+)
 set_target_properties(ShowLimit PROPERTIES SUFFIX .auf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,5 +24,6 @@ target_link_libraries(ShowLimit comctl32 bcrypt)
 target_compile_options(ShowLimit
     PRIVATE
         "$<$<CXX_COMPILER_ID:MSVC>:/source-charset:utf-8>"
+        "$<$<CXX_COMPILER_ID:MSVC>:/execution-charset:shift_jis>"
 )
 set_target_properties(ShowLimit PROPERTIES SUFFIX .auf)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,23 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "binaryDir": "${sourceDir}/build",
+            "generator": "Visual Studio 17 2022",
+            "architecture": "Win32"
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "debug",
+            "configurePreset": "default",
+            "configuration": "Debug"
+        },
+        {
+            "name": "release",
+            "configurePreset": "default",
+            "configuration": "Release"
+        }
+    ]
+}

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,6 +1,6 @@
 # Credits
 
-## aviutl_exedit_sdk v1
+## aviutl_exedit_sdk v1.2
 
 https://github.com/ePi5131/aviutl_exedit_sdk
 


### PR DESCRIPTION
- 今までは `vendor` ディレクトリまたは任意のディレクトリにすでに配置されている `aviutl_exedit_sdk` を参照する設定でしたが、 `vendor` ディレクトリにサブモジュールとして追加しました。
- `aviutl_exedit_sdk` のバージョンが古かったので v1.2 に更新しました。
- ソースファイルのエンコーディングをUTF-8に変更しました。
- CMake用のプリセットを追加しました。
- GitHub Actions による自動ビルドの設定を追加しました。