### PR TITLE
:sparkles: feat: 表に拡張編集フィルタの使用状況を追加

### DIFF
--- a/src/ExEditProfiler.hpp
+++ b/src/ExEditProfiler.hpp
@@ -37,6 +37,10 @@ public:
     static constexpr size_t kExtensionOffset = 0x14cb58;
     static constexpr size_t kExtensionMax = 0x800;
 
+    static constexpr size_t kExEditFilterArrayOffset = 0x187c98;
+    static constexpr size_t kExEditFilterCountOffset = 0x146248;
+    static constexpr size_t kExEditFilterMax = 512;
+
     static constexpr std::string_view kExEditName{ "拡張編集" };
     static constexpr std::string_view kExEdit92{ "拡張編集(exedit) version 0.92 by ＫＥＮくん" };
 
@@ -93,6 +97,11 @@ public:
         return GetNamesBufferUsed(kExtensionOffset, kExtensionMax);
     }
 
+    size_t GetExEditFilterNum() const {
+        if (!IsSupported()) return 0;
+        return ReadUInt32(kExEditFilterCountOffset);
+    }
+
     void WriteProfile(std::ostream& dest, const ScriptsOption& opt);
 
 private:
@@ -116,6 +125,17 @@ private:
         if (!IsSupported()) return 0;
         auto buf = GetNamesBuffer(offset);
         return GetNamesBufferLength(buf, size);
+    }
+
+    template<typename T>
+    T* GetPtr(size_t offset) const {
+        if (!IsSupported()) return nullptr;
+        return reinterpret_cast<T*>(reinterpret_cast<size_t>(exedit_->dll_hinst) + offset);
+    }
+
+    uint32_t ReadUInt32(size_t offset) const {
+        if (!IsSupported()) return 0;
+        return *GetPtr<uint32_t>(offset);
     }
 
     void WriteExEditDetail(std::ostream& dest);

--- a/src/show_limit.cpp
+++ b/src/show_limit.cpp
@@ -5,6 +5,8 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <array>
+#include <tuple>
 
 #include <aviutl.hpp>
 
@@ -126,21 +128,27 @@ bool CreateFilterWindow(FilterPlugin* fp) {
     }
 
     // items
-    SetListItem(0, "スクリプト名 ANM", g_exedit_profiler.GetAnmUsed(), ExEditProfiler::kAnmMax);
-    SetListItem(1, "スクリプト名 OBJ", g_exedit_profiler.GetObjUsed(), ExEditProfiler::kObjMax);
-    SetListItem(2, "スクリプト名 SCN", g_exedit_profiler.GetScnUsed(), ExEditProfiler::kScnMax);
-    SetListItem(3, "スクリプト名 CAM", g_exedit_profiler.GetCamUsed(), ExEditProfiler::kCamMax);
-    SetListItem(4, "スクリプト名 TRA", g_exedit_profiler.GetTraUsed(), ExEditProfiler::kTraMax);
-    SetListItem(5, "図形名", g_exedit_profiler.GetFigureUsed(), ExEditProfiler::kFigureMax);
-    SetListItem(6, "トランジション名", g_exedit_profiler.GetTransitionUsed(), ExEditProfiler::kTransitionMax);
-    SetListItem(7, "EXA/EXO", g_exedit_profiler.GetExaExoUsed(), ExEditProfiler::kExaExoMax);
-    SetListItem(8, "exedit extension", g_exedit_profiler.GetExtensionUsed(), ExEditProfiler::kExtensionMax);
-    SetListItem(9, "入力プラグイン", g_aviutl_profiler.GetInputNum(), AviUtlProfiler::kInputCountMax);
-    SetListItem(10, "出力プラグイン", g_aviutl_profiler.GetOutputNum(), AviUtlProfiler::kOutputCountMax);
-    SetListItem(11, "フィルタプラグイン", g_aviutl_profiler.GetFilterNum(), AviUtlProfiler::kFilterCountMax);
-    SetListItem(12, "色変換プラグイン", g_aviutl_profiler.GetColorNum(), AviUtlProfiler::kColorCountMax);
-    SetListItem(13, "言語拡張リソースプラグイン", g_aviutl_profiler.GetLanguageNum(), AviUtlProfiler::kLanguageCountMax);
-    SetListItem(14, "add_menu_item", g_aviutl_profiler.GetMenuItemNum(), AviUtlProfiler::kMenuItemMax);
+    const auto items = std::to_array<std::tuple<const char *, size_t, size_t>>({
+        {"スクリプト名 ANM", g_exedit_profiler.GetAnmUsed(), ExEditProfiler::kAnmMax},
+        {"スクリプト名 OBJ", g_exedit_profiler.GetObjUsed(), ExEditProfiler::kObjMax},
+        {"スクリプト名 SCN", g_exedit_profiler.GetScnUsed(), ExEditProfiler::kScnMax},
+        {"スクリプト名 CAM", g_exedit_profiler.GetCamUsed(), ExEditProfiler::kCamMax},
+        {"スクリプト名 TRA", g_exedit_profiler.GetTraUsed(), ExEditProfiler::kTraMax},
+        {"図形名", g_exedit_profiler.GetFigureUsed(), ExEditProfiler::kFigureMax},
+        {"トランジション名", g_exedit_profiler.GetTransitionUsed(), ExEditProfiler::kTransitionMax},
+        {"EXA/EXO", g_exedit_profiler.GetExaExoUsed(), ExEditProfiler::kExaExoMax},
+        {"exedit extension", g_exedit_profiler.GetExtensionUsed(), ExEditProfiler::kExtensionMax},
+        {"拡張編集フィルタ", g_exedit_profiler.GetExEditFilterNum(), ExEditProfiler::kExEditFilterMax},
+        {"入力プラグイン", g_aviutl_profiler.GetInputNum(), AviUtlProfiler::kInputCountMax},
+        {"出力プラグイン", g_aviutl_profiler.GetOutputNum(), AviUtlProfiler::kOutputCountMax},
+        {"フィルタプラグイン", g_aviutl_profiler.GetFilterNum(), AviUtlProfiler::kFilterCountMax},
+        {"色変換プラグイン", g_aviutl_profiler.GetColorNum(), AviUtlProfiler::kColorCountMax},
+        {"言語拡張リソースプラグイン", g_aviutl_profiler.GetLanguageNum(), AviUtlProfiler::kLanguageCountMax},
+        {"add_menu_item", g_aviutl_profiler.GetMenuItemNum(), AviUtlProfiler::kMenuItemMax},
+    });
+    for (size_t i = 0; i < items.size(); i++) {
+        SetListItem(i, std::get<0>(items[i]), std::get<1>(items[i]), std::get<2>(items[i]));
+    }
 
     // プラグイングループ
     HWND hwnd = CreateWindowEx(


### PR DESCRIPTION
Issue #15 にて情報提供のあった拡張編集フィルタについて、読み込まれた数、上限数を表に追加で表示するようにしました。
読み込まれている拡張編集フィルタの一覧を出力する機能については、情報の取得方法がすぐには分からなかったため、このプルリクエストでは一旦見送りとします。