### PR TITLE
:sparkles: feat: Susieプラグイン情報を追加

### DIFF
--- a/src/ExEditProfiler.cpp
+++ b/src/ExEditProfiler.cpp
@@ -199,3 +199,20 @@ void ExEditProfiler::WriteExEditFilterProfile(std::ostream& dest, const std::fil
         WritePluginData(dest, hasher, opt, aviutl_dir, filter->name, filter->information, buf);
     }
 }
+
+void ExEditProfiler::WriteSusiePluginProfile(std::ostream& dest, const std::filesystem::path& aviutl_dir, const PluginsOption& opt)
+{
+    if (!IsSupported()) return;
+
+    dest << kBullet1 << "Susieプラグイン\n";
+
+    Sha256Hasher hasher;
+    const auto spi = GetPtr<ExEdit::structSPI>(kSusiePluginOffset);
+    for (size_t i = 0; i < kSusiePluginMax; i++) {
+        if (spi[i].hmodule == NULL) continue;
+
+        char buf[MAX_PATH];
+        GetModuleFileName(spi[i].hmodule, buf, MAX_PATH);
+        WritePluginData(dest, hasher, opt, aviutl_dir, spi[i].information, spi[i].extension, buf);
+    }
+}

--- a/src/ExEditProfiler.hpp
+++ b/src/ExEditProfiler.hpp
@@ -5,6 +5,7 @@
 #include <string_view>
 
 #include <aviutl.hpp>
+#include <exedit.hpp>
 
 #include "ScriptsOption.hpp"
 #include "PluginsOption.hpp"
@@ -42,6 +43,9 @@ public:
     static constexpr size_t kExEditFilterArrayOffset = 0x187c98;
     static constexpr size_t kExEditFilterCountOffset = 0x146248;
     static constexpr size_t kExEditFilterMax = 512;
+
+    static constexpr size_t kSusiePluginOffset = 0x2321f0;
+    static constexpr size_t kSusiePluginMax = 32;
 
     static constexpr std::string_view kExEditName{ "拡張編集" };
     static constexpr std::string_view kExEdit92{ "拡張編集(exedit) version 0.92 by ＫＥＮくん" };
@@ -104,9 +108,23 @@ public:
         return ReadUInt32(kExEditFilterCountOffset);
     }
 
+    size_t GetSusiePluginNum() const {
+        if (!IsSupported()) return 0;
+        const auto spi = GetPtr<ExEdit::structSPI>(kSusiePluginOffset);
+        size_t count = 0;
+        for (size_t i = 0; i < kSusiePluginMax; i++) {
+            if (spi[i].hmodule != NULL) {
+                count++;
+            }
+        }
+        return count;
+    }
+
     void WriteProfile(std::ostream& dest, const ScriptsOption& opt);
 
     void WriteExEditFilterProfile(std::ostream& dest, const std::filesystem::path& aviutl_dir, const PluginsOption& opt);
+
+    void WriteSusiePluginProfile(std::ostream& dest, const std::filesystem::path& aviutl_dir, const PluginsOption& opt);
 
 private:
     AviUtl::FilterPlugin* exedit_;

--- a/src/show_limit.cpp
+++ b/src/show_limit.cpp
@@ -141,6 +141,7 @@ bool CreateFilterWindow(FilterPlugin* fp) {
         {"EXA/EXO", g_exedit_profiler.GetExaExoUsed(), ExEditProfiler::kExaExoMax},
         {"exedit extension", g_exedit_profiler.GetExtensionUsed(), ExEditProfiler::kExtensionMax},
         {"拡張編集フィルタ", g_exedit_profiler.GetExEditFilterNum(), ExEditProfiler::kExEditFilterMax},
+        {"Susieプラグイン", g_exedit_profiler.GetSusiePluginNum(), ExEditProfiler::kSusiePluginMax},
         {"入力プラグイン", g_aviutl_profiler.GetInputNum(), AviUtlProfiler::kInputCountMax},
         {"出力プラグイン", g_aviutl_profiler.GetOutputNum(), AviUtlProfiler::kOutputCountMax},
         {"フィルタプラグイン", g_aviutl_profiler.GetFilterNum(), AviUtlProfiler::kFilterCountMax},
@@ -319,6 +320,7 @@ BOOL func_WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam, AviUtl:
             fs::path aviutl_path = g_aviutl_profiler.GetAviUtlPath();
             fs::path aviutl_dir = aviutl_path.parent_path();
             g_exedit_profiler.WriteExEditFilterProfile(os, aviutl_dir, opt);
+            g_exedit_profiler.WriteSusiePluginProfile(os, aviutl_dir, opt);
             CopyToClipboard(os.str());
             break;
         }
@@ -333,6 +335,7 @@ BOOL func_WndProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam, AviUtl:
                     fs::path aviutl_path = g_aviutl_profiler.GetAviUtlPath();
                     fs::path aviutl_dir = aviutl_path.parent_path();
                     g_exedit_profiler.WriteExEditFilterProfile(ofs, aviutl_dir, opt);
+                    g_exedit_profiler.WriteSusiePluginProfile(ofs, aviutl_dir, opt);
                 }
                 catch (const std::exception& e) {
                     std::ostringstream os;


### PR DESCRIPTION
Issue #19 にて情報提供のあったSusieプラグインについての対応です。
拡張編集プラグインで読み込まれるSusieプラグインについて、他プラグインと同様に読み込まれている数、残りの枠数、上限、割合を表に表示するようにしました。
また、プラグイン情報のテキスト出力時にSusieプラグインの情報も出力するようにしました。